### PR TITLE
Ability to authenticate with the schema registry via Cognito OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,17 @@ end
 
 # Messaging objects created with the same registry_url will now use the fake server.
 ```
+
+### Cognito (Oauth) Compatibility
+
+Connection to the schema registry can work with Cognito OAuth. It will request an auth token the first time it connects to the registry and will attempt to refresh the token when it expires. Pass the following arguments to use OAuth:
+
+```ruby
+avro = AvroTurf::Messaging.new(
+  logger: ...,
+  registry_url: ...,
+  oauth_url: <the authorisation server URL>,
+  oauth_client_id: <the oauth client id>,
+  oauth_client_secret: <the oauth client secret>
+)
+```

--- a/lib/avro_turf/connection_manager.rb
+++ b/lib/avro_turf/connection_manager.rb
@@ -1,0 +1,63 @@
+require 'avro_turf/connection_wrapper'
+require 'avro_turf/connection_wrapper_with_token_auth'
+
+class AvroTurf::ConnectionManager
+  def initialize(url,
+                 logger:,
+                 proxy: nil,
+                 user: nil,
+                 password: nil,
+                 ssl_ca_file: nil,
+                 client_cert: nil,
+                 client_key: nil,
+                 client_key_pass: nil,
+                 client_cert_data: nil,
+                 client_key_data: nil,
+                 oauth_url: nil,
+                 oauth_client_id: nil,
+                 oauth_client_secret: nil)
+    @logger = logger
+
+    @connection_wrapper = if [oauth_client_id, oauth_client_secret].none?(&:nil?)
+                            ::AvroTurf::ConnectionWrapperWithAuthToken.new(
+                              url,
+                              logger: logger,
+                              proxy: proxy,
+                              user: user,
+                              password: password,
+                              ssl_ca_file: ssl_ca_file,
+                              client_cert: client_cert,
+                              client_key: client_key,
+                              client_key_pass: client_key_pass,
+                              client_cert_data: client_cert_data,
+                              client_key_data: client_key_data,
+                              oauth_url: oauth_url,
+                              oauth_client_id: oauth_client_id,
+                              oauth_client_secret: oauth_client_secret
+                            )
+                          else
+                            ::AvroTurf::ConnectionWrapper.new(
+                              url,
+                              logger: logger,
+                              proxy: proxy,
+                              user: user,
+                              password: password,
+                              ssl_ca_file: ssl_ca_file,
+                              client_cert: client_cert,
+                              client_key: client_key,
+                              client_key_pass: client_key_pass,
+                              client_cert_data: client_cert_data,
+                              client_key_data: client_key_data
+                            )
+                          end
+    logger.debug("#{self.class.name}: using #{connection_wrapper.class.name} connection wrapper")
+  end
+
+  def with_connection(&block)
+    connection_wrapper.with_connection(&block)
+  end
+
+  private
+
+  attr_reader :logger, :connection_wrapper
+end

--- a/lib/avro_turf/connection_wrapper.rb
+++ b/lib/avro_turf/connection_wrapper.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'excon'
+
+class AvroTurf::ConnectionWrapper
+  CONTENT_TYPE = 'application/vnd.schemaregistry.v1+json'
+
+  def initialize(
+    url,
+    logger:,
+    proxy: nil,
+    user: nil,
+    password: nil,
+    ssl_ca_file: nil,
+    client_cert: nil,
+    client_key: nil,
+    client_key_pass: nil,
+    client_cert_data: nil,
+    client_key_data: nil
+  )
+    @logger = logger
+    @proxy = proxy
+    @url = url
+    @user = user
+    @password = password
+    @ssl_ca_file = ssl_ca_file
+    @client_cert = client_cert
+    @client_key = client_key
+    @client_key_pass = client_key_pass
+    @client_cert_data = client_cert_data
+    @client_key_data = client_key_data
+  end
+
+  def with_connection
+    yield connection
+  end
+
+  attr_reader :connection
+
+  private
+
+  def headers
+    headers = {
+      'Content-Type' => CONTENT_TYPE
+    }
+    headers[:proxy] = proxy unless proxy.nil?
+    headers
+  end
+
+  def connection
+    @connection ||= Excon.new(
+      url,
+      headers: headers,
+      user: user,
+      password: password,
+      ssl_ca_file: ssl_ca_file,
+      client_cert: client_cert,
+      client_key: client_key,
+      client_key_pass: client_key_pass,
+      client_cert_data: client_cert_data,
+      client_key_data: client_key_data
+    )
+  end
+
+  attr_reader :logger, :proxy, :url, :user, :password, :ssl_ca_file, :client_cert, :client_key, :client_key_pass, :client_cert_data, :client_key_data
+end

--- a/lib/avro_turf/connection_wrapper_with_token_auth.rb
+++ b/lib/avro_turf/connection_wrapper_with_token_auth.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class AvroTurf::ConnectionWrapperWithAuthToken < AvroTurf::ConnectionWrapper
+  REFRESH_TOKEN_TRIES = 4
+
+  def initialize(url,
+                 logger:,
+                 proxy: nil,
+                 user: nil,
+                 password: nil,
+                 ssl_ca_file: nil,
+                 client_cert: nil,
+                 client_key: nil,
+                 client_key_pass: nil,
+                 client_cert_data: nil,
+                 client_key_data: nil,
+                 oauth_url: nil,
+                 oauth_client_id: nil,
+                 oauth_client_secret: nil)
+    @oauth_url = oauth_url
+    @oauth_client_id = oauth_client_id
+    @oauth_client_secret = oauth_client_secret
+    @semaphore = Mutex.new
+    @logger = logger
+    @refresh_token_retries_remaining = REFRESH_TOKEN_TRIES
+    refresh_token
+
+    super(url,
+      logger: logger,
+      proxy: proxy,
+      user: user,
+      password: password,
+      ssl_ca_file: ssl_ca_file,
+      client_cert: client_cert,
+      client_key: client_key,
+      client_key_pass: client_key_pass,
+      client_cert_data: client_cert_data,
+      client_key_data: client_key_data)
+  end
+
+  def with_connection
+    refresh_token if token_needs_refresh?
+    result = super
+    @refresh_token_retries_remaining = REFRESH_TOKEN_TRIES
+    result
+  rescue Excon::Error::Unauthorized
+    raise if refresh_token_retries_remaining < 1
+
+    logger.info("Encountered unauthorised response, will retry with fresh token (#{refresh_token_retries_remaining} retries remaining)...")
+    refresh_token
+    retry
+  end
+
+  private
+
+  def refresh_token
+    logger.info('Waiting to refresh auth token...')
+    semaphore.synchronize do
+      @refresh_token_retries_remaining -= 1
+      logger.info("Checking if auth token needs refresh (current token set to expire at #{token_expires_at})...")
+      return unless token_needs_refresh?
+
+      logger.info('Auth token needs refresh. Refreshing...')
+      current_time_utc = Time.now.utc
+      refresh_uri = URI.parse(oauth_url)
+      refresh_connection = Excon.new(
+        refresh_uri.to_s.chomp(refresh_uri.path),
+        headers: refresh_token_header)
+      response = refresh_connection.post(path: refresh_uri.path, expects: 200, body: 'grant_type=client_credentials')
+      json_response = JSON.parse(response.body)
+      @token = json_response['access_token']
+      @token_expires_at = current_time_utc + json_response['expires_in'].to_i
+      remove_instance_variable(:@connection) if instance_variable_defined?(:@connection)
+      logger.info("Auth token refreshed (new token set to expire at #{token_expires_at}).")
+    end
+  rescue => e
+    logger.error('Exception whilst refreshing token:')
+    logger.error(e)
+  end
+
+  def token_needs_refresh?
+    token.nil? || token_expires_at.nil? || Time.now.utc > token_expires_at
+  end
+
+  def headers
+    super.merge('Authorization' => "Bearer #{token}")
+  end
+
+  def base64_refresh_auth
+    Base64.strict_encode64("#{oauth_client_id}:#{oauth_client_secret}")
+  end
+
+  def refresh_token_header
+    {
+      'Authorization' => "Basic #{base64_refresh_auth}",
+      'Content-Type' => 'application/x-www-form-urlencoded',
+    }
+  end
+
+  attr_reader :oauth_url, :oauth_client_id, :oauth_client_secret, :token_expires_at, :semaphore, :token, :refresh_token_retries_remaining
+end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -120,14 +120,16 @@ class AvroTurf
     # validate    - The boolean for performing complete message validation before
     #               encoding it, Avro::SchemaValidator::ValidationError with
     #               a descriptive message will be raised in case of invalid message.
+    # register    - The boolean for determining if registering a new schema is allowed
+    #               when encoding a message
     #
     # Returns the encoded data as a String.
-    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false)
+    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false, register: true)
       schema, schema_id = if schema_id
         fetch_schema_by_id(schema_id)
       elsif subject && version
         fetch_schema(subject: subject, version: version)
-      elsif schema_name
+      elsif schema_name && register
         register_schema(subject: subject, schema_name: schema_name, namespace: namespace)
       else
         raise ArgumentError.new('Neither schema_name nor schema_id nor subject + version provided to determine the schema.')

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -55,6 +55,9 @@ class AvroTurf
     # client_key_pass      - Password to go with client_key (optional).
     # client_cert_data     - In-memory client certificate (optional).
     # client_key_data      - In-memory client private key to go with client_cert_data (optional).
+    # oauth_url            - URL at which an oauth token can be generated
+    # oauth_client_id      - id/secret combination that can be used to generate a temporary oauth token
+    # oauth_client_secret  - id/secret combination that can be used to generate a temporary oauth token
     def initialize(
       registry: nil,
       registry_url: nil,
@@ -71,7 +74,10 @@ class AvroTurf
       client_key: nil,
       client_key_pass: nil,
       client_cert_data: nil,
-      client_key_data: nil
+      client_key_data: nil,
+      oauth_url: nil,
+      oauth_client_id: nil,
+      oauth_client_secret: nil
     )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
@@ -89,6 +95,9 @@ class AvroTurf
           client_key_pass: client_key_pass,
           client_cert_data: client_cert_data,
           client_key_data: client_key_data,
+          oauth_url: oauth_url,
+          oauth_client_id: oauth_client_id,
+          oauth_client_secret: oauth_client_secret,
           path_prefix: registry_path_prefix
         )
       )

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server_with_oauth.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server_with_oauth.rb
@@ -1,0 +1,15 @@
+class FakeConfluentSchemaRegistryServerWithOauth < FakeConfluentSchemaRegistryServer
+  helpers do
+    def global_config
+      # Snatch the auth header and return it with the global config so we can check it was provided
+      self.class.global_config.merge!(request.env.slice('HTTP_AUTHORIZATION'))
+      self.class.global_config
+    end
+  end
+
+  get "/config/:subject" do
+    # Make requesting an unauthorized subject name trigger a 401 response to help us test token refresh
+    halt(401, {}) if params[:subject] == 'unauthorized'
+    CONFIGS.fetch(params[:subject], global_config).to_json
+  end
+end

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
 require 'avro_turf/confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'
+require 'avro_turf/test/fake_confluent_schema_registry_server_with_oauth'
 
 describe AvroTurf::ConfluentSchemaRegistry do
   let(:user) { "abc" }
@@ -8,8 +9,10 @@ describe AvroTurf::ConfluentSchemaRegistry do
   let(:client_cert) { "test client cert" }
   let(:client_key) { "test client key" }
   let(:client_key_pass) { "test client key password" }
+  let(:oauth_client_id) { "test oauth_client_id" }
+  let(:oauth_client_secret) { "test oauth_client_secret" }
 
-  it_behaves_like "a confluent schema registry client" do
+  it_behaves_like "a confluent schema registry client", "cert" do
     let(:registry) {
       described_class.new(
         registry_url,
@@ -21,12 +24,24 @@ describe AvroTurf::ConfluentSchemaRegistry do
     }
   end
 
-  it_behaves_like "a confluent schema registry client" do
+  it_behaves_like "a confluent schema registry client", "password" do
     let(:registry) {
       described_class.new(
         registry_url,
         user: user,
         password: password,
+      )
+    }
+  end
+
+  it_behaves_like "a confluent schema registry client", "oauth" do
+    let(:registry) {
+      described_class.new(
+        registry_url,
+        logger: logger,
+        oauth_url: oauth_url,
+        oauth_client_id: oauth_client_id,
+        oauth_client_secret: oauth_client_secret
       )
     }
   end


### PR DESCRIPTION
- Ability to authenticate with the schema registry via Cognito OAuth
- Will fetch a bearer token to be passed with requests to the schema registry
- If the bearer token expires, it will fetch a new one
- It will retry up to 3 times to fetch a new bearer token before giving up