### PR TITLE
[SRE-1207] Some tweaks to make registering new schemas easier

### DIFF
--- a/lib/avro_turf/connection_wrapper_with_token_auth.rb
+++ b/lib/avro_turf/connection_wrapper_with_token_auth.rb
@@ -23,7 +23,6 @@ class AvroTurf::ConnectionWrapperWithAuthToken < AvroTurf::ConnectionWrapper
     @semaphore = Mutex.new
     @logger = logger
     @refresh_token_retries_remaining = REFRESH_TOKEN_TRIES
-    refresh_token
 
     super(url,
       logger: logger,

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -104,6 +104,9 @@ class AvroTurf
       @schemas_by_id = {}
     end
 
+    attr_accessor :schema_store
+    attr_reader :registry
+
     # Encodes a message using the specified schema.
     #
     # message     - The message that should be encoded. Must be compatible with


### PR DESCRIPTION
[Do not refresh the auth token on initialize](https://github.com/meetcleo/avro_turf/commit/337d8ce6277e44f0b9da3a48cc5cc3815c26ccc3)

Delay the fetching of the auth token to when the connection to the schema registry is used.

This is to prevent making an HTTP call during initialization of AvroTurf, which, if done as part of a Rails initializer would have a negative impact on startup performance of a Rails app.

[Expose messaging.schema_store and messaging.registry](https://github.com/meetcleo/avro_turf/commit/64ad1b91716b34fc8211028db1ece84a4f9b4742)

This provides accessors for the `schema_store` and `registry`.

Allowing read + write access to the schema store to allow dynamic setting of a schema store with a different path, and give ability to trigger loading of schemas on demand.
Allowing read access to the registry so that we can do things like check compatibility (which is exposed on the registry class).