### PR TITLE
Ability to delete subjects

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,7 +17,7 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions check compatible?
+  %i(subjects subject_versions check compatible? delete_subject
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -109,6 +109,11 @@ class AvroTurf::ConfluentSchemaRegistry
     put("/config/#{subject}", body: config.to_json)
   end
 
+  # Delete all versions for a subject
+  def delete_subject(subject)
+    delete("/subjects/#{subject}")
+  end
+
   private
 
   def get(path, **options)
@@ -121,6 +126,10 @@ class AvroTurf::ConfluentSchemaRegistry
 
   def post(path, **options)
     request(path, method: :post, **options)
+  end
+
+  def delete(path, **options)
+    request(path, method: :delete, **options)
   end
 
   def request(path, **options)


### PR DESCRIPTION
Provides the ability to delete all versions of a subject from the schema registry.

Useful if one is doing testing and wants to clear out their subjects.