### PR TITLE
[PLT-XXX] Let some operations retry

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -85,7 +85,7 @@ class AvroTurf::ConfluentSchemaRegistry
   # http://docs.confluent.io/3.1.2/schema-registry/docs/api.html#compatibility
   def compatible?(subject, schema, version = 'latest')
     data = post("/compatibility/subjects/#{subject}/versions/#{version}",
-                expects: [200, 404], body: { schema: schema.to_s }.to_json)
+                expects: [200, 404], body: { schema: schema.to_s }.to_json, idempotent: true)
     data.fetch('is_compatible', false) unless data.has_key?('error_code')
   end
 
@@ -117,7 +117,7 @@ class AvroTurf::ConfluentSchemaRegistry
   private
 
   def get(path, **options)
-    request(path, method: :get, **options)
+    request(path, method: :get, **options.merge(idempotent: true))
   end
 
   def put(path, **options)


### PR DESCRIPTION
This marks some schema registry operations as `idempotent`. By setting [this](https://github.com/excon/excon?tab=readme-ov-file#timeouts-and-retries) Excon will retry the operations up to 4 times.

Adding this because we have [seen](https://dashboard.heroku.com/apps/cleo-production-private/activity/releases/ec618830-6f30-4348-8e4c-e1e9e8762c41) deploys fail due to intermittent connectivity issues with the schema registry.

The Excon debug output let's you see some of it's tracking of retries:

```
  :retries_remaining   => 1
  :retry_errors        => [
    Excon::Error::Timeout
    Excon::Error::Socket
    Excon::Error::HTTPStatus
  ]
  :retry_limit         => 4
```