### PR TITLE
Let `compatibility` check retry on connection problems

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -107,7 +107,7 @@ class AvroTurf::ConfluentSchemaRegistry
   # http://docs.confluent.io/3.1.2/schema-registry/docs/api.html#compatibility
   def compatible?(subject, schema, version = 'latest')
     data = post("/compatibility/subjects/#{subject}/versions/#{version}",
-                expects: [200, 404], body: { schema: schema.to_s }.to_json)
+                expects: [200, 404], body: { schema: schema.to_s }.to_json, **retry_options)
     data.fetch('is_compatible', false) unless data.has_key?('error_code')
   end
 


### PR DESCRIPTION
This marks the compatibility schema registry operation as `idempotent`. By setting [this](https://github.com/excon/excon?tab=readme-ov-file#timeouts-and-retries) Excon will retry the operations up to 4 times.

Adding this because we have [seen](https://dashboard.heroku.com/apps/cleo-production-private/activity/releases/ec618830-6f30-4348-8e4c-e1e9e8762c41) deploys fail due to intermittent connectivity issues with the schema registry.