### PR TITLE
[PLT-XXX] Better control of HTTP connections

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -19,10 +19,16 @@ class AvroTurf::ConfluentSchemaRegistry
     path_prefix: nil,
     connection_pool_size: nil,
     tcp_nodelay: nil,
-    persistent_connection: nil
+    persistent_connection: nil,
+    connect_timeout: nil,
+    read_timeout: nil,
+    write_timeout: nil,
+    retry_limit: nil,
+    instrumentor: nil
   )
     @path_prefix = path_prefix
     @logger = logger
+    @retry_limit = retry_limit
     @connection_manager = ::AvroTurf::ConnectionManager.new(
       url,
       logger: logger,
@@ -40,7 +46,11 @@ class AvroTurf::ConfluentSchemaRegistry
       oauth_client_secret: oauth_client_secret,
       connection_pool_size: connection_pool_size,
       tcp_nodelay: tcp_nodelay,
-      persistent_connection: persistent_connection
+      persistent_connection: persistent_connection,
+      connect_timeout: connect_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout,
+      instrumentor: instrumentor
     )
   end
 
@@ -56,7 +66,8 @@ class AvroTurf::ConfluentSchemaRegistry
   def retry_options
     {
       idempotent: true,
-      retry_errors: RETRY_ERRORS
+      retry_errors: RETRY_ERRORS,
+      retry_limit:,
     }
   end
 
@@ -137,6 +148,8 @@ class AvroTurf::ConfluentSchemaRegistry
   end
 
   private
+
+  attr_reader :retry_limit
 
   def get(path, **options)
     options.merge!(retry_options)

--- a/lib/avro_turf/connection_manager.rb
+++ b/lib/avro_turf/connection_manager.rb
@@ -18,7 +18,11 @@ class AvroTurf::ConnectionManager
                  oauth_client_secret: nil,
                  connection_pool_size: nil,
                  tcp_nodelay: nil,
-                 persistent_connection: nil)
+                 persistent_connection: nil,
+                 connect_timeout: nil,
+                 read_timeout: nil,
+                 write_timeout: nil,
+                 instrumentor: nil)
     @logger = logger
 
     @connection_wrapper = if [oauth_client_id, oauth_client_secret].none?(&:nil?)
@@ -39,7 +43,11 @@ class AvroTurf::ConnectionManager
                               oauth_client_secret: oauth_client_secret,
                               connection_pool_size: connection_pool_size,
                               tcp_nodelay: tcp_nodelay,
-                              persistent_connection: persistent_connection
+                              persistent_connection: persistent_connection,
+                              connect_timeout: connect_timeout,
+                              read_timeout: read_timeout,
+                              write_timeout: write_timeout,
+                              instrumentor: instrumentor
                             )
                           else
                             ::AvroTurf::ConnectionWrapper.new(
@@ -56,7 +64,11 @@ class AvroTurf::ConnectionManager
                               client_key_data: client_key_data,
                               connection_pool_size: connection_pool_size,
                               tcp_nodelay: tcp_nodelay,
-                              persistent_connection: persistent_connection
+                              persistent_connection: persistent_connection,
+                              connect_timeout: connect_timeout,
+                              read_timeout: read_timeout,
+                              write_timeout: write_timeout,
+                              instrumentor: instrumentor
                             )
                           end
     logger.debug("#{self.class.name}: using #{connection_wrapper.class.name} connection wrapper")

--- a/lib/avro_turf/connection_wrapper.rb
+++ b/lib/avro_turf/connection_wrapper.rb
@@ -23,7 +23,11 @@ class AvroTurf::ConnectionWrapper
     client_key_data: nil,
     connection_pool_size: nil,
     tcp_nodelay: nil,
-    persistent_connection: nil
+    persistent_connection: nil,
+    connect_timeout: nil,
+    read_timeout: nil,
+    write_timeout: nil,
+    instrumentor: nil
   )
     @logger = logger
     @proxy = proxy
@@ -39,6 +43,10 @@ class AvroTurf::ConnectionWrapper
     @connection_pool_size = connection_pool_size || CONNECTION_POOL_SIZE
     @tcp_nodelay = tcp_nodelay.nil? ? TCP_NODELAY : tcp_nodelay
     @persistent_connection = persistent_connection.nil? ? PERSISTENT_CONNECTION : persistent_connection
+    @connect_timeout = connect_timeout
+    @read_timeout = read_timeout
+    @write_timeout = write_timeout
+    @instrumentor = instrumentor
   end
 
   def with_connection
@@ -67,8 +75,7 @@ class AvroTurf::ConnectionWrapper
   end
 
   def connection
-    Excon.new(
-      url,
+    options = {
       headers: headers,
       user: user,
       tcp_nodelay: tcp_nodelay,
@@ -79,7 +86,15 @@ class AvroTurf::ConnectionWrapper
       client_key: client_key,
       client_key_pass: client_key_pass,
       client_cert_data: client_cert_data,
-      client_key_data: client_key_data
+      client_key_data: client_key_data,
+      connect_timeout: connect_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    }
+    options[:instrumentor] = instrumentor if instrumentor
+    Excon.new(
+      url,
+      options
     )
   end
 
@@ -89,5 +104,6 @@ class AvroTurf::ConnectionWrapper
     end
   end
   attr_reader :logger, :proxy, :url, :user, :password, :ssl_ca_file, :client_cert, :client_key, :client_key_pass,
-              :client_cert_data, :client_key_data, :connection_pool_size, :tcp_nodelay, :persistent_connection
+              :client_cert_data, :client_key_data, :connection_pool_size, :tcp_nodelay, :persistent_connection,
+              :connect_timeout, :read_timeout, :write_timeout, :instrumentor
 end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -21,6 +21,9 @@ class AvroTurf
   # 1: https://github.com/confluentinc/schema-registry
   class Messaging
     MAGIC_BYTE = [0].pack('C').freeze
+    DEFAULT_CONNECT_TIMEOUT = 5
+    DEFAULT_API_TIMEOUT = 60
+    DEFAULT_RETRY_LIMIT = 4
 
     class DecodedMessage
       attr_reader :schema_id, :writer_schema, :reader_schema, :message
@@ -78,7 +81,12 @@ class AvroTurf
       connection_pool_size: nil,
       tcp_nodelay: nil,
       persistent_connection: nil,
-      cache: nil
+      cache: nil,
+      connect_timeout: nil,
+      read_timeout: nil,
+      write_timeout: nil,
+      retry_limit: nil,
+      instrumentor: nil
     )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
@@ -102,7 +110,12 @@ class AvroTurf
           path_prefix: registry_path_prefix,
           connection_pool_size: connection_pool_size,
           tcp_nodelay: tcp_nodelay,
-          persistent_connection: persistent_connection
+          persistent_connection: persistent_connection,
+          connect_timeout: connect_timeout || DEFAULT_CONNECT_TIMEOUT,
+          read_timeout: read_timeout || DEFAULT_API_TIMEOUT,
+          write_timeout: write_timeout || DEFAULT_API_TIMEOUT,
+          retry_limit: retry_limit || DEFAULT_RETRY_LIMIT,
+          instrumentor: instrumentor
         ),
         cache: cache
       )


### PR DESCRIPTION
Adds the following:
- customizable timeouts
- customizable retries
- instrumentation

Adding these in as these are important settings to help us manage timeouts in a more granular fashion in order to protect our web dyno resources.