### PR TITLE
[PLT-XXX] host_authorization for FakeConfluentSchemaRegistryServer 

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -72,7 +72,7 @@ class AvroTurf::ConfluentSchemaRegistry
   end
 
   def fetch(id)
-    @logger.info "Fetching schema with id #{id}"
+    @logger.debug "Fetching schema with id #{id}"
     data = get("/schemas/ids/#{id}")
     data.fetch('schema')
   end
@@ -82,7 +82,7 @@ class AvroTurf::ConfluentSchemaRegistry
 
     id = data.fetch('id')
 
-    @logger.info "Registered schema for subject `#{subject}`; id = #{id}"
+    @logger.debug "Registered schema for subject `#{subject}`; id = #{id}"
 
     id
   end

--- a/lib/avro_turf/connection_wrapper_with_token_auth.rb
+++ b/lib/avro_turf/connection_wrapper_with_token_auth.rb
@@ -59,7 +59,7 @@ class AvroTurf::ConnectionWrapperWithAuthToken < AvroTurf::ConnectionWrapper
   rescue Excon::Error::Unauthorized
     raise if refresh_token_retries_remaining < 1
 
-    logger.info("Encountered unauthorised response, will retry with fresh token (#{refresh_token_retries_remaining} retries remaining)...")
+    logger.debug("Encountered unauthorised response, will retry with fresh token (#{refresh_token_retries_remaining} retries remaining)...")
     refresh_token
     retry
   end
@@ -67,13 +67,13 @@ class AvroTurf::ConnectionWrapperWithAuthToken < AvroTurf::ConnectionWrapper
   private
 
   def refresh_token
-    logger.info('Waiting to refresh auth token...')
+    logger.debug('Waiting to refresh auth token...')
     semaphore.synchronize do
       @refresh_token_retries_remaining -= 1
-      logger.info("Checking if auth token needs refresh (current token set to expire at #{token_expires_at})...")
+      logger.debug("Checking if auth token needs refresh (current token set to expire at #{token_expires_at})...")
       return unless token_needs_refresh?
 
-      logger.info('Auth token needs refresh. Refreshing...')
+      logger.debug('Auth token needs refresh. Refreshing...')
       current_time_utc = Time.now.utc
       refresh_uri = URI.parse(oauth_url)
       options = {
@@ -89,7 +89,7 @@ class AvroTurf::ConnectionWrapperWithAuthToken < AvroTurf::ConnectionWrapper
       json_response = JSON.parse(response.body)
       @token = json_response['access_token']
       @token_expires_at = current_time_utc + json_response['expires_in'].to_i
-      logger.info("Auth token refreshed (new token set to expire at #{token_expires_at}).")
+      logger.debug("Auth token refreshed (new token set to expire at #{token_expires_at}).")
     end
   rescue StandardError => e
     logger.error('Exception whilst refreshing token:')

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -11,6 +11,12 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
 
   @global_config = DEFAULT_GLOBAL_CONFIG.dup
 
+  set :host_authorization, ->() do
+    {
+      allow_if: Proc.new { true }
+    }
+  end
+
   class << self
     attr_reader :global_config
   end

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -294,12 +294,12 @@ shared_examples_for 'a confluent schema registry client' do |auth_mechanism|
       it 'tries to fetch a new authorization token 3 times' do
         skip('Not using oauth') if auth_mechanism != 'oauth'
 
-        allow(logger).to receive(:info)
+        allow(logger).to receive(:debug)
         expect { registry.subject_config('unauthorized') }.to raise_error(Excon::Error::Unauthorized)
 
-        expect(logger).to have_received(:info).with('Encountered unauthorised response, will retry with fresh token (3 retries remaining)...').exactly(1).times
-        expect(logger).to have_received(:info).with('Encountered unauthorised response, will retry with fresh token (2 retries remaining)...').exactly(1).times
-        expect(logger).to have_received(:info).with('Encountered unauthorised response, will retry with fresh token (1 retries remaining)...').exactly(1).times
+        expect(logger).to have_received(:debug).with('Encountered unauthorised response, will retry with fresh token (3 retries remaining)...').exactly(1).times
+        expect(logger).to have_received(:debug).with('Encountered unauthorised response, will retry with fresh token (2 retries remaining)...').exactly(1).times
+        expect(logger).to have_received(:debug).with('Encountered unauthorised response, will retry with fresh token (1 retries remaining)...').exactly(1).times
       end
     end
   end


### PR DESCRIPTION
Per [this](https://github.com/sinatra/sinatra/pull/2053) change, "Defaults to .localhost, .test and any IP address in development mode."

We want our fake server to be able to respond to any request, hence we allow all hosts.

Also: [Switch log lines from info to debug to keep log noise to a minimum](https://github.com/meetcleo/avro_turf/commit/d667184421d52ad641cb2f9342c89a0b17ccfde8)